### PR TITLE
Task 2 - Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,22 @@
-# README
-
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
+# List of rake task to generate basket and add apple in basket
 Things you may want to cover:
 
-* Ruby version
+* This will create 50 Baskets in DB
+```
+rake data:generate_basket
+```
 
-* System dependencies
+* This will create number of Baskets in DB
+```
+rake data:generate_basket[pass any number here]
+```
 
-* Configuration
+* This will add apple in existing baskets (this will auto pick data in rake task)
+```
+rake data:add_apple_to_basket
+```
 
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+* This will add apple in existing baskets (first arges is variety and second one is count)
+```
+rake data:add_apple_to_basket[apple,400]
+```

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,36 @@
+namespace :data do
+
+  desc "add apples in basket"
+  task :add_apple_to_basket, [:variety, :count] => :environment do |task, args|
+    vrty = args[:variety] || ["Kashmiri Apple", "Green Apple", "Washington Apple"].sample
+    ct = args[:count].to_i || rand(1..50)
+    for i in (1..ct) do
+      bkt = Apple.where(variety: vrty).last&.basket
+      if bkt.present? && bkt.fill_rate < 100
+        basket = bkt
+      else
+        basket = Basket.find_by(fill_rate: 0)
+      end
+      if basket.present?
+        Apple.create(basket: basket, variety: vrty)
+        rt = (basket.reload.apples.count.to_f/basket.capacity.to_f)*100
+        basket.update(fill_rate: rt)
+        puts "Apple added to baskets | Apple counter ::#{i} | Apple variety :: #{vrty}"
+      else
+        puts "All baskets are full. We couldn't find the place for #{ct-i} apples"
+        break;
+      end
+    end
+  end
+
+  desc "Generate baskets"
+  task :generate_basket, [:count] => :environment do |task, args|
+    bskt_ct = args[:count].to_i || 50
+    for i in (1..bskt_ct) do
+      num = rand(2..27)
+      Basket.create(capacity: num, fill_rate: 0)
+    end
+    puts "Basket generated"
+  end
+
+end


### PR DESCRIPTION
Write a rake task add_apple_to_basket that accepts two arguments, variety and count. Once executed the task should:

Find an available basket that has 0 or is filled with at least 1 apple of the same sort as the variety argument.
Create as many apple records as are passed in the count argument.
Whenever a basket has a new apple, the fill_rate should be re-calculated as a percentage of the count of the associated records divided by the capacity of the basket.
If the selected basket is full, the remainder of apples should be carried over to the next basket.
If no baskets are available, the rake task should output the next message as a standard output: "All baskets are full. We couldn't find the place for \[X\] apples"